### PR TITLE
Graphics option in write_result_session

### DIFF
--- a/src/pyxfoil/xfoilresult.py
+++ b/src/pyxfoil/xfoilresult.py
@@ -179,6 +179,11 @@ def write_result_session(name: str, datfilepath: str, numpnl: int,
 
     with open(sesfilepath, 'wt') as file:
 
+        # PLOP
+        # G    # to not open graphics window with ppar
+        file.write('PLOP\nG\n')
+        file.write('\n')
+
         file.write('load {:s}\n'.format(datfilepath))
 
         if ppar is not None:

--- a/src/pyxfoil/xfoilresult.py
+++ b/src/pyxfoil/xfoilresult.py
@@ -156,7 +156,7 @@ def write_result_session(name: str, datfilepath: str, numpnl: int,
                          alpha: float, mach: float | None = None,
                          Re: float | None = None, ppar: int | None = None,
                          xtrtop: float = 1.0, xtrbot: float = 1.0,
-                         ncrit: float = None) -> tuple[str, str]:
+                         ncrit: float = None, graphics: bool = False) -> tuple[str, str]:
 
     resname = name.replace(' ', '_')
     resname += f'_{numpnl:d}_{alpha:g}'
@@ -179,10 +179,11 @@ def write_result_session(name: str, datfilepath: str, numpnl: int,
 
     with open(sesfilepath, 'wt') as file:
 
-        # PLOP
-        # G    # to not open graphics window with ppar
-        file.write('PLOP\nG\n')
-        file.write('\n')
+        if not graphics:
+            # do not open graphics window with ppar
+            file.write('plop\n')
+            file.write('g\n')
+            file.write('\n')
 
         file.write('load {:s}\n'.format(datfilepath))
 


### PR DESCRIPTION
Adds a graphics argument to write_results_session function in xfoilresults.py. If graphics = false, write the session files (.ses) with "plop g" at the top to disable the opening of graphics windows from commands like ppar. This change greatly sped up and fixed graphics buffering issues for my usage.